### PR TITLE
This PR fixes issue #9 

### DIFF
--- a/helpers/SteroidsMapper.ts
+++ b/helpers/SteroidsMapper.ts
@@ -37,6 +37,22 @@ export class AppendOps{
         
         return this._mapper;
     }
+
+    async fromAsync(appendFunc: Function) {
+        if (appendFunc === undefined)
+            throw new SteroidMapperException("Steroids mapper doesn't accept null values for the from() function, should be a function");
+
+        if (this._obj instanceof Array){
+            let asyncArr = [];
+            for (let i=0;i<this._obj.length;i++)
+                asyncArr.push(this.appendObject(this._obj[i], appendFunc));
+            
+            await Promise.all(asyncArr);
+        }else
+            await this.appendObject(this._obj, appendFunc);
+        
+        return this._mapper;
+    }
 }
 
 export class MapOps{


### PR DESCRIPTION
Method name : **fromAsync**

Example Use case :  
                             ` 
                                       await steroid.mapper(jsonObject)
                                                    .append(""keyToAppend").
                                                    .fromAsync( async (obj) => {// your logic which can be executed async})
                                `