### PR TITLE
Fixes Issue #20

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,5 +44,5 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "version": "0.1.8"
+  "version": "0.1.9"
 }

--- a/plugins/data/relational/IRelationalDatabase.ts
+++ b/plugins/data/relational/IRelationalDatabase.ts
@@ -1,13 +1,18 @@
 export interface IRelationalDatabase {
     executeQuery<T>(type: {new(): T;},query:string):Promise<T[]>;
     getDataSet(retrievalPlan:IRetrievalPlan[]):Promise<any>;
-    getMultipleResultSets(query:string, ...dataSetNames:string[]):Promise<any>;
+    getMultipleResultSets(query:string, ...dataSetNames:IDataSet[]):Promise<any>;
 }
 
 export interface IVariables {
     name:string,
     value?: any,
     values?: any
+}
+
+export interface IDataSet {
+    id: string,
+    name: string
 }
 
 export interface IRetrievalPlan {


### PR DESCRIPTION
The new implementation requires to pass a unique identifier for each variable using the `IDataset` interface.

eg usage - 

`let query = select nameid from var1; select jobid, nameid from var2;
let var1Data: IDataset = {
"id": "nameid",
"name": "var1"
}
let var2Data: IDataset = {
"id": "jobid",
"name": "var2"
}
let {var1, var2} = await steroid.database().relational().getMultipleResultSets(query, var1Data, var2Data); `

**Note**
as you can see nameid is the unique identifier column for var1 but nameid is also part of the result set of var2 in that case we need to pass in var1 as the first parameter.